### PR TITLE
Improve color picker

### DIFF
--- a/scripts/canvas-pixi-utils.js
+++ b/scripts/canvas-pixi-utils.js
@@ -1,54 +1,11 @@
 
-/**
- * https://github.com/League-of-Foundry-Developers/simplefog/blob/master/js/helpers.js
- */
 export function readPixel (target, x = 0, y = 0) {
-  const { renderer } = canvas.app
-  let resolution
-  let renderTexture
-  let generated = false
-  if (target instanceof PIXI.RenderTexture) {
-    renderTexture = target
-  } else {
-    renderTexture = renderer.generateTexture(target)
-    generated = true
-  }
-  if (renderTexture) {
-    resolution = renderTexture.baseTexture.resolution
-    renderer.renderTexture.bind(renderTexture)
-  }
-  const pixel = new Uint8Array(4)
-  // read pixels to the array
-  const { gl } = renderer
-  gl.readPixels(x * resolution, y * resolution, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel)
-  if (generated) {
-    renderTexture.destroy(true)
-  }
-  return pixel
+  return canvas.app.renderer.plugins.extract.pixels(target, new PIXI.Rectangle(x, y, 1, 1))
 }
 
 
 export function readAllPixels (target) {
-  const { renderer } = canvas.app
-  let renderTexture
-  let generated = false
-  if (target instanceof PIXI.RenderTexture) {
-    renderTexture = target
-  } else {
-    renderTexture = renderer.generateTexture(target)
-    generated = true
-  }
-  if (renderTexture) {
-    renderer.renderTexture.bind(renderTexture)
-  }
-  const pixel = new Uint8Array(4 * target.width * target.height)
-  // read pixels to the array
-  const { gl } = renderer
-  gl.readPixels(0, 0, target.width, target.height, gl.RGBA, gl.UNSIGNED_BYTE, pixel)
-  if (generated) {
-    renderTexture.destroy(true)
-  }
-  return pixel
+  return canvas.app.renderer.plugins.extract.pixels(target)
 }
 
 

--- a/scripts/eyedropper-color-pick.js
+++ b/scripts/eyedropper-color-pick.js
@@ -1,10 +1,9 @@
-import { getLocalMousePosition, getScreenMousePosition } from './mouse-utils.js'
+import { getScreenMousePosition } from './mouse-utils.js'
 import { readPixel, rgbaToHex } from './canvas-pixi-utils.js'
 import { getSetting, MODULE_ID } from './precise-drawing-tools.js'
 
-export const colorPickFromCursor = async (fillOrStroke, backgroundOnly = false) => {
-  const { color, alpha } = getMousePixelColorAndAlpha(backgroundOnly)
-  console.log(`%c${color}`, `background: ${color}`)
+export const colorPickFromCursor = async (fillOrStroke) => {
+  const { color, alpha } = getMousePixelColorAndAlpha()
   await updateDrawingDefaults(
     fillOrStroke === 'fill' ? {
       fillColor: color,
@@ -16,77 +15,23 @@ export const colorPickFromCursor = async (fillOrStroke, backgroundOnly = false) 
   setDrawingToolGuiColor(color)
 }
 
-function getMousePixelColorAndAlpha (backgroundOnly) {
-  const colorWithAlpha = getMousePixel(backgroundOnly)
-  const color = colorWithAlpha.substr(0, 1 + 6)
-  const alpha = parseInt(colorWithAlpha.substr(1 + 6, 2), 16) / 255
+function getMousePixelColorAndAlpha () {
+  const colorWithAlpha = getMousePixel()
+  const color = colorWithAlpha.substring(0, 7)
+  const alpha = parseInt(colorWithAlpha.substring(7, 9), 16) / 255
   return { color, alpha }
 }
 
-function getMousePixel (backgroundOnly) {
-  const pixelRGBA = backgroundOnly ? getMousePixelOnLayer(canvas.background) : getMousePixelOnScreen()
+function getMousePixel () {
+  const { x, y } = getScreenMousePosition()
+  const pixelRGBA = readPixel(canvas.primary.renderTexture, x, y)
   // converting alpha from 0—255 to 0—1
   const pixelRGBa = [...pixelRGBA.subarray(0, 3), pixelRGBA[3] / 255]
   let colorWithAlpha = rgbaToHex(...pixelRGBa)
   if (CONFIG.debug.eyedropper) {
     console.log(`%c${colorWithAlpha}    `, `background: ${colorWithAlpha}`)
   }
-  if (!colorWithAlpha.startsWith('#000000') || !backgroundOnly) {
-    return colorWithAlpha
-  }
-  colorWithAlpha = '#' + ((1 << 24) + canvas.backgroundColor).toString(16).slice(1) + 'ff'
-  if (CONFIG.debug.eyedropper) {
-    console.log(`found nothing, so default %c  ${colorWithAlpha}`, `background: ${colorWithAlpha}`)
-  }
   return colorWithAlpha
-}
-
-let screenRenderCache = null // caches the 2d context of the canvas app render
-const getMousePixelOnScreen = () => {
-  let context
-  if (screenRenderCache === null) {
-    canvas.app.render()
-    const canv = canvas.app.renderer.extract.canvas()
-    context = canv.getContext('2d')
-    screenRenderCache = context
-  } else {
-    context = screenRenderCache
-  }
-  const { x, y } = getScreenMousePosition()
-  return context.getImageData(x, y, 1, 1).data
-}
-
-const resetScreenRenderCache = () => {
-  if (screenRenderCache !== null) {
-    if (CONFIG.debug.eyedropper) {
-      console.debug(`ShemetzMacros | Resetting screen render cache for eyedropper`)
-    }
-    screenRenderCache = null
-  }
-}
-
-let resetCooldownTimer = null
-const resetScreenRenderCacheSoon = () => {
-  if (screenRenderCache !== null) {
-    // prevent constantly rerendering when the user is panning
-    if (resetCooldownTimer !== null) {
-      clearTimeout(resetCooldownTimer)
-    }
-    resetCooldownTimer = setTimeout(() => {
-      resetScreenRenderCache()
-    }, 500)
-  }
-}
-
-/**
- * note:  returns alpha in range 0—255
- */
-function getMousePixelOnLayer (layer) {
-  const mPos = getLocalMousePosition()
-  const tPos = layer.getLocalBounds()
-  const x = mPos.x - tPos.x
-  const y = mPos.y - tPos.y
-  return readPixel(layer, x, y)
 }
 
 async function updateDrawingDefaults (changedData) {
@@ -111,41 +56,27 @@ const isFillOrStroke = () => {
   return game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.SHIFT)
 }
 
-const shouldPickFromBackgroundOnly = () => {
-  return game.keyboard.isModifierActive(KeyboardManager.MODIFIER_KEYS.ALT)
-}
-
-let flipFlopRender = false
-
 function onMouseMoveColorEyedropperTool () {
-  // silly hack, but without it the color doesn't change until the mouse stops moving.
-  // looks like reading a pixel prevents us from rendering on the same frame or something.
-  // so the solution is to only read pixels once every two frames.
-  flipFlopRender = !flipFlopRender
-  if (!flipFlopRender) return
-  const { color } = getMousePixelColorAndAlpha(shouldPickFromBackgroundOnly())
+  const { color } = getMousePixelColorAndAlpha()
   setDrawingToolGuiColor(color)
 }
 
 function deactivateEyedropperTool () {
   canvas.stage.off('mousemove', onMouseMoveColorEyedropperTool)
   canvas.stage.off('mousedown', onMouseMoveColorEyedropperTool)
-  Hooks.off('canvasPan', resetScreenRenderCacheSoon)
 }
 
 function activateColorPickFromCursor () {
   deactivateEyedropperTool()
   // set color in default drawing config.  alt to switch fill/stroke
   const fillOrStroke = isFillOrStroke() ? 'fill' : 'stroke'
-  const backgroundOnly = shouldPickFromBackgroundOnly()
-  return colorPickFromCursor(fillOrStroke, backgroundOnly)
+  return colorPickFromCursor(fillOrStroke)
 }
 
 function startShowingEyedropperColor () {
   // wherever cursor is, that color is set as eyedropper tool background
   canvas.stage.on('mousemove', onMouseMoveColorEyedropperTool)
   canvas.stage.on('mousedown', onMouseMoveColorEyedropperTool)
-  Hooks.on('canvasPan', resetScreenRenderCacheSoon)
 }
 
 export const hookEyedropperColorPicker = () => {
@@ -153,7 +84,7 @@ export const hookEyedropperColorPicker = () => {
   game.keybindings.register(MODULE_ID, 'eyedropper', {
     name: 'Eyedropper (Color Pick)',
     hint: 'Pick the color of the current pixel under the cursor, and set it as current stroke color.' +
-      ' Hold Shift to change the fill color instead, and hold Alt to pick pixels only from the background image.',
+      ' Hold Shift to change the fill color instead.',
     editable: [
       {
         key: 'KeyK'
@@ -166,7 +97,6 @@ export const hookEyedropperColorPicker = () => {
         return false
       }
       if ($(`.scene-control.active`).attr('data-control') === 'drawings') {
-        resetScreenRenderCache()
         startShowingEyedropperColor()
         onMouseMoveColorEyedropperTool()
         return true // consumed
@@ -180,7 +110,6 @@ export const hookEyedropperColorPicker = () => {
       }
       if ($(`.scene-control.active`).attr('data-control') === 'drawings') {
         activateColorPickFromCursor()
-        resetScreenRenderCache()
         return true // consumed
       } else {
         return false


### PR DESCRIPTION
I changed the color picker such that the color is picked pre-lighting (from `canvas.primary.renderTexture`). This makes more sense to me because the lighting is also applied to the drawing; so if the color is picked post-lighting the drawing color doesn't match. I think that is what the Alt option was trying to achieve. The Alt option is broken in v10, because `canvas.background` doesn't exist anymore. The Alt option was removed.

I think the changes to `readPixel` make it incompatible with v9, which uses an older pixi.js version, which doesn't have the rectangle parameter yet. Not sure if you want to keep v9 compatibility at this point. If yes, then keep the old `readPixel`.

The flip-flop hack seems to be unnecessary after the changes.

`substr` is deprecated so I replaced it with `substring`.

Before changes:
![colorpicker-before](https://user-images.githubusercontent.com/31905376/208134278-696d3f4d-5197-439d-956b-011fe75bc38c.gif)

After changes:
![colorpicker-after](https://user-images.githubusercontent.com/31905376/208132352-950d0b5f-6c61-489d-bf39-b3bebd355a15.gif)
